### PR TITLE
Create .rcalc dir on startup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ var rootCmd = &cobra.Command{
 
 		rCalcDir := path.Join(dir, ".rcalc")
 
-		rcalc.Run(rCalcDir)
+		rcalc.Run(rCalcDir, true)
 	},
 }
 

--- a/rcalc/rcalc.go
+++ b/rcalc/rcalc.go
@@ -6,8 +6,16 @@ import (
 	"path"
 )
 
-func Run(stackDataFolder string) {
+func Run(stackDataFolder string, createFolder bool) {
 
+	if createFolder {
+		if _, err := os.Stat(stackDataFolder); os.IsNotExist(err) {
+			err := os.Mkdir(stackDataFolder, 0755)
+			if err != nil {
+				return
+			}
+		}
+	}
 	stackDataFilePath := path.Join(stackDataFolder, "stack.protobuf")
 
 	var stack = CreateSaveOnDiskStack(stackDataFilePath)


### PR DESCRIPTION
If `.rcalc` does not exist, create if on startup.
This makes is possible to save the stack afterwards