### PR TITLE
Fix grammar for signed numbers

### DIFF
--- a/grammar/Rcalc.g4
+++ b/grammar/Rcalc.g4
@@ -2,10 +2,18 @@
 grammar Rcalc;
 
 // Tokens
-DOT: '.' ;
-INT_NUMBER: [-]?[0-9]+ ;
-DECIMAL_NUMBER: [-]?[0-9]*DOT[0-9]+ |  [-]?[0-9]+(DOT[0-9]*)? ;
-SCIENTIFIC_NUMBER: [-]?[0-9]*(DOT[0-9])?[eE][+-]?[0-9]+ ;
+fragment DOT: '.' ;
+fragment INT_NUMBER: [0-9]+ ;
+fragment DECIMAL_NUMBER: [0-9]*DOT[0-9]+ | [0-9]+(DOT[0-9]*)? ;
+fragment SCIENTIFIC_NUMBER: [0-9]*(DOT[0-9])?[eE][+-]?[0-9]+ ;
+
+// Numbers are not signed, signs are added at the parser level to handle various different
+// cases which are different between the RPN and arithmetics expressions
+NUMBER
+    : INT_NUMBER
+    | DECIMAL_NUMBER
+    | SCIENTIFIC_NUMBER
+    ;
 
 OP_ADD: '+';
 OP_SUB: '-';
@@ -46,10 +54,15 @@ KW_END: 'end';
 
 NAME: [a-zA-Z_][a-zA-Z0-9_]*;
 
-WHITESPACE: [ \r\n\t]+ -> skip;
+// We define whitespaces but we cannot skip them since in RPN mode
+// 2-3 must not parse and 2 - 3 and 2 -3 are not the same thing
+// This is still useful to specify them at various places in the grammar
+WHITESPACE: [ \r\n\t]+;
 
 // Rules
-start : instr+ EOF;
+start : instr_seq EOF;
+
+instr_seq: WHITESPACE* instr (WHITESPACE+ instr)* WHITESPACE*;
 
 instr
     : action_or_var_call         # InstrActionOrVarCall
@@ -68,43 +81,37 @@ op
     ;
 
 if_then_else
-    : KW_IF instr+ KW_THEN instr+ (KW_ELSE instr+)* KW_END ;
+    : KW_IF instr_seq KW_THEN instr_seq (KW_ELSE instr_seq)* KW_END ;
 
-start_next_loop: KW_START instr+ KW_NEXT ;
-for_next_loop: KW_FOR variableDeclaration instr+ KW_NEXT ;
+start_next_loop: KW_START instr_seq KW_NEXT ;
+for_next_loop: KW_FOR WHITESPACE* variableDeclaration instr_seq KW_NEXT ;
 
 program_declaration:
-    PROG_OPEN instr+ PROG_CLOSE  # ProgramDeclaration
+    PROG_OPEN instr_seq PROG_CLOSE  # ProgramDeclaration
     ;
 
 local_var_creation
-    : '->' variableDeclaration+ program_declaration # LocalVarCreationProgram
+    : '->' (WHITESPACE* variableDeclaration)+ WHITESPACE* program_declaration # LocalVarCreationProgram
 //    | '->' variableDeclaration+ identifier          # LocalVarCreationAlgebraicExpr
     ;
 
 variableDeclaration: NAME #DeclarationVariable;
 
 variable
-    : number                      # VariableNumber
+    : (OP_ADD|OP_SUB)?NUMBER     # VariableNumber
     | quoted_algebraic_expression # VariableAlgebraicExpression
     | list                        # VariableList
     | vector                      # VariableVector
     ;
 
-number
-    : INT_NUMBER        # NumberInt
-    | DECIMAL_NUMBER    # NumberDecimal
-    | SCIENTIFIC_NUMBER # NumberScientific
-    ;
-
-quoted_algebraic_expression: QUOTE alg_expression QUOTE ;
+quoted_algebraic_expression: QUOTE WHITESPACE* alg_expression WHITESPACE* QUOTE ;
 
 alg_expression
-   : alg_mulExpression ((OP_ADD | OP_SUB) alg_mulExpression)* # AlgExprAddSub
+   : alg_mulExpression WHITESPACE* ((OP_ADD | OP_SUB) WHITESPACE* alg_mulExpression)* # AlgExprAddSub
    ;
 
 alg_mulExpression
-   : alg_powExpression ((OP_MUL | OP_DIV) alg_powExpression)* # AlgExprMulDiv
+   : alg_powExpression WHITESPACE* ((OP_MUL | OP_DIV) WHITESPACE* alg_powExpression)* # AlgExprMulDiv
    ;
 
 alg_powExpression
@@ -112,14 +119,14 @@ alg_powExpression
    ;
 
 alg_signedAtom
-   : OP_ADD alg_signedAtom # AlgExprAddSignedAtom
-   | OP_SUB alg_signedAtom # AlgExprSubSignedAtom
+   : OP_ADD WHITESPACE* alg_signedAtom # AlgExprAddSignedAtom
+   | OP_SUB WHITESPACE* alg_signedAtom # AlgExprSubSignedAtom
    | alg_func_call         # AlgExprFuncAtom
    | alg_atom              # AlgExprAtom
    ;
 
 alg_atom
-   : number                                # AlgExprNumber
+   : NUMBER                                # AlgExprNumber
    | alg_variable                          # AlgExprVariable
    | PAREN_OPEN alg_expression PAREN_CLOSE # AlgExprParen
    ;

--- a/rcalc/expression_parser.go
+++ b/rcalc/expression_parser.go
@@ -313,6 +313,11 @@ func (l *RcalcParserListener) BackToParentAlgebraicContext() {
 }
 
 func (l *RcalcParserListener) TokenVisited(token int) {
+	if token == parser.RcalcLexerWHITESPACE {
+		// ignore whitespace
+		// we cannot ask the grammar to skip it in order to make a diference between 2- 3 and 2 -3
+		return
+	}
 	l.currentPc.TokenVisited(token)
 	if l.currentAlgebraicPc != nil {
 		l.currentAlgebraicPc.TokenVisited(token)

--- a/rcalc/expression_parser_test.go
+++ b/rcalc/expression_parser_test.go
@@ -31,8 +31,9 @@ func TestAntlrParse2Numbers(t *testing.T) {
 	for _, expr := range numbersToParse {
 		t.Run(expr, func(t *testing.T) {
 			elt, err := ParseToActions(expr, "Test", registry)
-			assert.NoError(t, err, "Parse error : %s", err)
-			assert.IsType(t, elt[0], &VariablePutOnStackActionDesc{})
+			if assert.NoError(t, err, "Parse error : %s", err) {
+				assert.IsType(t, elt[0], &VariablePutOnStackActionDesc{})
+			}
 		})
 	}
 }

--- a/rcalc/expression_parser_test.go
+++ b/rcalc/expression_parser_test.go
@@ -237,12 +237,9 @@ func TestAlgebraicExpressionParsing(t *testing.T) {
 		{
 			literal: "'1 +2 - 5'", value: decimal.NewFromInt(-2),
 		},
-		/*
-			{
-				//TODO This does not parse
-				literal: "'1 +2 -5'", value: decimal.NewFromInt(-2),
-			},
-		*/
+		{
+			literal: "'1 +2 -5'", value: decimal.NewFromInt(-2),
+		},
 		{
 			literal: "'1+ 2'",
 			value:   decimal.NewFromInt(3),


### PR DESCRIPTION
Since `2 - 3` and `2 -3` are 2 different expressions in RPN mode, we cannot ignore whitespaces at the parser level.
=> We add it in many places in the grammar to allow them.

In order to share the number definition between the algebraic expressions and RPN expressions, we make the `NUMBER` token "unsigned" and handle the sign in the parser on a per case basis.