### PR TITLE
Introduce expansion of operations on lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ compile: $(TARGET)
 test: $(GRAMMAR_WITNESS)
 	go test ./rcalc ./main
 
+run: $(TARGET)
+	$(TARGET)
+
 clean:
 	$(RM) -vrf bin
 	$(RM) -vrf $(GRAMMAR_OUTPUT_DIR)

--- a/rcalc/action.go
+++ b/rcalc/action.go
@@ -236,6 +236,7 @@ func initRegistry() *ActionRegistry {
 	reg.RegisterActions(&StackPackage)
 	reg.RegisterActions(&MemoryPackage)
 	reg.RegisterActions(&StructOpsPackage)
+	reg.RegisterActions(&ListPackage)
 	reg.Register(&DebugOp)
 	reg.Register(&VersionOp)
 	reg.Register(&EXIT_ACTION)

--- a/rcalc/action.go
+++ b/rcalc/action.go
@@ -2,6 +2,7 @@ package rcalc
 
 import (
 	"fmt"
+
 	"github.com/shopspring/decimal"
 	"troisdizaines.com/rcalc/rcalc/protostack"
 )
@@ -99,7 +100,8 @@ func (a *ActionDesc) Display() string {
 // OperationDesc implementation of Action interface
 type OperationCommonDesc struct {
 	ActionCommonDesc
-	nbArgs int
+	nbArgs    int
+	nbResults int
 }
 
 type CheckTypeFn func(elts ...Variable) (bool, error)
@@ -107,23 +109,34 @@ type OperationApplyFn func(system System, elts ...Variable) []Variable
 
 type OperationDesc struct {
 	OperationCommonDesc
+	expandable  bool
 	checkTypeFn CheckTypeFn
 	applyFn     OperationApplyFn
 }
 
 var _ Action = (*OperationDesc)(nil)
 
-func NewOperationDesc(opCode string, nbArgs int, checkTypeFn CheckTypeFn, applyFn OperationApplyFn) OperationDesc {
+func newOperationDesc(opCode string, nbArgs int, checkTypeFn CheckTypeFn, nbResults int, applyFn OperationApplyFn, expandable bool) OperationDesc {
 	return OperationDesc{
 		OperationCommonDesc: OperationCommonDesc{
 			ActionCommonDesc: ActionCommonDesc{
 				opCode: opCode,
 			},
-			nbArgs: nbArgs,
+			nbArgs:    nbArgs,
+			nbResults: nbResults,
 		},
+		expandable:  expandable,
 		checkTypeFn: checkTypeFn,
 		applyFn:     applyFn,
 	}
+}
+
+func NewOperationDesc(opCode string, nbArgs int, checkTypeFn CheckTypeFn, nbResults int, applyFn OperationApplyFn) OperationDesc {
+	return newOperationDesc(opCode, nbArgs, checkTypeFn, nbResults, applyFn, false)
+}
+
+func NewExpandableOperationDesc(opCode string, nbArgs int, checkTypeFn CheckTypeFn, nbResults int, applyFn OperationApplyFn) OperationDesc {
+	return newOperationDesc(opCode, nbArgs, checkTypeFn, nbResults, applyFn, true)
 }
 
 func (op *OperationDesc) String() string {
@@ -138,14 +151,65 @@ func (op *OperationDesc) CheckTypes(elts ...Variable) (bool, error) {
 	return op.checkTypeFn(elts...)
 }
 
+func (op *OperationDesc) NbResults() int {
+	return op.nbResults
+}
+
 func (op *OperationDesc) Apply(runtimeContext *RuntimeContext) error {
 	inputs, err := runtimeContext.stack.PopN(op.NbArgs())
 	if err != nil {
 		return err
 	}
-	results := op.applyFn(runtimeContext.system, inputs...)
-	for _, elt := range results {
-		runtimeContext.stack.Push(elt)
+	if op.expandable {
+		argIsList := make([]bool, op.NbArgs())
+		isExpanded := false
+		listLength := 0
+		for argIdx := 0; argIdx < op.NbArgs(); argIdx++ {
+			if inputs[argIdx].getType() == TYPE_LIST {
+				argIsList[argIdx] = true
+				listLength = inputs[argIdx].asListVar().Size()
+				isExpanded = true
+			}
+		}
+		// TODO check on listLength consistency
+		if isExpanded {
+			// We need as many result list as the applied function return results
+			results := make([][]Variable, op.NbResults())
+			for idx := range results {
+				results[idx] = make([]Variable, listLength)
+			}
+			for i := 0; i < listLength; i++ {
+				tempInputs := make([]Variable, op.NbArgs())
+				for inputIdx := 0; inputIdx < op.NbArgs(); inputIdx++ {
+					if argIsList[inputIdx] {
+						tempInputs[inputIdx] = inputs[inputIdx].asListVar().items[i]
+					} else {
+						tempInputs[inputIdx] = inputs[inputIdx]
+					}
+				}
+				tempResults := op.applyFn(runtimeContext.system, tempInputs...)
+
+				for tmpResultIdx, tempResult := range tempResults {
+					results[tmpResultIdx][i] = tempResult
+				}
+			}
+			for _, result := range results {
+				resultAsList := CreateListVariable(result)
+				fmt.Printf("Result: %s\n", resultAsList.display())
+				runtimeContext.stack.Push(resultAsList)
+			}
+		} else {
+			// not expanded case
+			results := op.applyFn(runtimeContext.system, inputs...)
+			for _, elt := range results {
+				runtimeContext.stack.Push(elt)
+			}
+		}
+	} else {
+		results := op.applyFn(runtimeContext.system, inputs...)
+		for _, elt := range results {
+			runtimeContext.stack.Push(elt)
+		}
 	}
 	return nil
 }

--- a/rcalc/expression_parser_algebraic.go
+++ b/rcalc/expression_parser_algebraic.go
@@ -2,6 +2,7 @@ package rcalc
 
 import (
 	"fmt"
+
 	"github.com/shopspring/decimal"
 	"troisdizaines.com/rcalc/rcalc/parser"
 )

--- a/rcalc/op.go
+++ b/rcalc/op.go
@@ -2,8 +2,9 @@ package rcalc
 
 import (
 	"fmt"
-	"github.com/shopspring/decimal"
 	"strings"
+
+	"github.com/shopspring/decimal"
 )
 
 func CheckNoop(elts ...Variable) (bool, error) {
@@ -44,12 +45,19 @@ func CheckGen(types []Type) CheckTypeFn {
 	}
 }
 
-func NewStackOp(opCode string, nbArgs int, fn PureOperationApplyFn) OperationDesc {
-	return NewOperationDesc(opCode, nbArgs, CheckNoop, OpToActionFn(fn))
+func ExpandableOpToActionFn(opFn PureOperationApplyFn) OperationApplyFn {
+	return func(system System, elts ...Variable) []Variable {
+
+		return opFn(elts...)
+	}
 }
 
-func NewStackOpWithtypeCheck(opCode string, nbArgs int, checkFn CheckTypeFn, fn PureOperationApplyFn) OperationDesc {
-	return NewOperationDesc(opCode, nbArgs, checkFn, OpToActionFn(fn))
+func NewStackOp(opCode string, nbArgs int, nbResults int, fn PureOperationApplyFn) OperationDesc {
+	return NewOperationDesc(opCode, nbArgs, CheckNoop, nbResults, OpToActionFn(fn))
+}
+
+func NewStackOpWithtypeCheck(opCode string, nbArgs int, checkFn CheckTypeFn, nbResults int, fn PureOperationApplyFn) OperationDesc {
+	return NewOperationDesc(opCode, nbArgs, checkFn, nbResults, OpToActionFn(fn))
 }
 
 func NewRawStackOpWithCheck(opCode string, nbArgs int, checkFn CheckTypeFn, fn ActionApplyFn) ActionDesc {
@@ -81,7 +89,7 @@ func A1R1NumericApplyFn(f A1R1NumericFn) PureOperationApplyFn {
 }
 
 func NewA1R1NumericOp(opCode string, decimalFunc A1R1NumericFn) OperationDesc {
-	return NewOperationDesc(opCode, 1, CheckAllNumerics, OpToActionFn(A1R1NumericApplyFn(decimalFunc)))
+	return NewOperationDesc(opCode, 1, CheckAllNumerics, 1, OpToActionFn(A1R1NumericApplyFn(decimalFunc)))
 }
 
 type A2R1NumericFn func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal
@@ -95,7 +103,11 @@ func A2R1NumericApplyFn(f A2R1NumericFn) PureOperationApplyFn {
 }
 
 func NewA2R1NumericOp(opCode string, decimalFunc A2R1NumericFn) OperationDesc {
-	return NewOperationDesc(opCode, 2, CheckAllNumerics, OpToActionFn(A2R1NumericApplyFn(decimalFunc)))
+	return NewOperationDesc(opCode, 2, CheckAllNumerics, 1, OpToActionFn(A2R1NumericApplyFn(decimalFunc)))
+}
+
+func NewExpandedA2R1NumericOp(opCode string, decimalFunc A2R1NumericFn) OperationDesc {
+	return NewOperationDesc(opCode, 2, CheckAllNumerics, 1, OpToActionFn(A2R1NumericApplyFn(decimalFunc)))
 }
 
 func GetEltAsBoolean(elts []Variable, idx int) bool {
@@ -124,7 +136,7 @@ func A1R1BooleanApplyFn(f A1R1BooleanFn) PureOperationApplyFn {
 }
 
 func NewA1R1BooleanOp(opCode string, booleanFunc A1R1BooleanFn) OperationDesc {
-	return NewOperationDesc(opCode, 1, CheckAllBooleans, OpToActionFn(A1R1BooleanApplyFn(booleanFunc)))
+	return NewOperationDesc(opCode, 1, CheckAllBooleans, 1, OpToActionFn(A1R1BooleanApplyFn(booleanFunc)))
 }
 
 type A2R1BooleanFn func(b1 bool, b2 bool) bool
@@ -138,7 +150,7 @@ func A2R1BooleanApplyFn(f A2R1BooleanFn) PureOperationApplyFn {
 }
 
 func NewA2R1BooleanOp(opCode string, booleanFunc A2R1BooleanFn) OperationDesc {
-	return NewOperationDesc(opCode, 2, CheckAllBooleans, OpToActionFn(A2R1BooleanApplyFn(booleanFunc)))
+	return NewOperationDesc(opCode, 2, CheckAllBooleans, 1, OpToActionFn(A2R1BooleanApplyFn(booleanFunc)))
 }
 
 type A2NumericR1BooleanFn func(d1 decimal.Decimal, d2 decimal.Decimal) bool
@@ -155,6 +167,7 @@ func NewA2NumericR1BooleanOp(opCode string, numericToBooleanFunc A2NumericR1Bool
 	return NewOperationDesc(opCode,
 		2,
 		CheckAllNumerics,
+		1,
 		OpToActionFn(A2NumericR1BooleanApplyFn(numericToBooleanFunc)))
 }
 
@@ -162,6 +175,7 @@ var VersionOp = NewOperationDesc(
 	"VERSION",
 	0,
 	func(elts ...Variable) (bool, error) { return true, nil },
+	1,
 	OpToActionFn(func(elts ...Variable) []Variable {
 		return []Variable{CreateNumericVariable(decimal.Zero)}
 	}))
@@ -170,6 +184,7 @@ var DebugOp = NewOperationDesc(
 	"debug",
 	1,
 	func(elts ...Variable) (bool, error) { return true, nil },
+	1,
 	OpToActionFn(func(elts ...Variable) []Variable {
 		fmt.Printf("%v\n", elts[0])
 		return []Variable{

--- a/rcalc/op.go
+++ b/rcalc/op.go
@@ -107,7 +107,7 @@ func NewA2R1NumericOp(opCode string, decimalFunc A2R1NumericFn) OperationDesc {
 }
 
 func NewExpandedA2R1NumericOp(opCode string, decimalFunc A2R1NumericFn) OperationDesc {
-	return NewOperationDesc(opCode, 2, CheckAllNumerics, 1, OpToActionFn(A2R1NumericApplyFn(decimalFunc)))
+	return NewExpandableOperationDesc(opCode, 2, CheckAllNumerics, 1, OpToActionFn(A2R1NumericApplyFn(decimalFunc)))
 }
 
 func GetEltAsBoolean(elts []Variable, idx int) bool {

--- a/rcalc/op_test.go
+++ b/rcalc/op_test.go
@@ -1,6 +1,7 @@
 package rcalc
 
 import (
+	"fmt"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -40,4 +41,139 @@ func TestCheckGenGeneric(t *testing.T) {
 	ok, err := CheckGen([]Type{TYPE_NUMERIC, TYPE_GENERIC})(i1, i2)
 	assert.True(t, ok)
 	assert.NoError(t, err)
+}
+
+type instrumentedExpandableFunctionFactory struct {
+	callingCount int
+}
+
+func (i *instrumentedExpandableFunctionFactory) GetApplyFunc() OperationApplyFn {
+	return func(system System, elts ...Variable) []Variable {
+		i.callingCount += 1
+		fmt.Printf("Applyfunc called\n")
+		return []Variable{CreateListVariable([]Variable{elts[0], elts[1]})}
+	}
+}
+
+func (i *instrumentedExpandableFunctionFactory) GetApplyFunc22() OperationApplyFn {
+	return func(system System, elts ...Variable) []Variable {
+		i.callingCount += 1
+		fmt.Printf("Applyfunc called\n")
+		return []Variable{elts[0], elts[1]}
+	}
+}
+
+func TestExpandableApply(t *testing.T) {
+
+	t.Run("NotExpandedCall", func(t *testing.T) {
+
+		funcBuilder := new(instrumentedExpandableFunctionFactory)
+
+		expandableTestOp := NewExpandableOperationDesc("testExpandableOp", 2, CheckNoop, 1, funcBuilder.GetApplyFunc())
+
+		var i1 = CreateNumericVariableFromInt(3)
+		var i2 = CreateNumericVariableFromInt(5)
+
+		stack := CreateStack()
+		stack.Push(i1)
+		stack.Push(i2)
+		runtimeContext := CreateRuntimeContext(nil, stack)
+		err := expandableTestOp.Apply(runtimeContext)
+		if assert.NoError(t, err) {
+			i3, err := stack.Pop()
+			if assert.NoError(t, err) {
+				//assert.Equal(t, decimal.NewFromInt(8), i3.asNumericVar().value, "3+5 should be 8 and not %d", i3.asNumericVar().value.IntPart())
+				assert.NotNilf(t, i3, "")
+				assert.Equal(t, CreateListVariable([]Variable{CreateNumericVariableFromInt(3), CreateNumericVariableFromInt(5)}), i3)
+			}
+		}
+	})
+	t.Run("ExpandedCall 2-1", func(t *testing.T) {
+
+		funcBuilder := new(instrumentedExpandableFunctionFactory)
+
+		expandableTestOp := NewExpandableOperationDesc("testExpandableOp", 2, CheckNoop, 1, funcBuilder.GetApplyFunc())
+
+		var i1 = CreateListVariable([]Variable{CreateNumericVariableFromInt(3), CreateNumericVariableFromInt(13)})
+		var i2 = CreateListVariable([]Variable{CreateNumericVariableFromInt(5), CreateNumericVariableFromInt(15)})
+
+		stack := CreateStack()
+		stack.Push(i1)
+		stack.Push(i2)
+		runtimeContext := CreateRuntimeContext(nil, stack)
+		err := expandableTestOp.Apply(runtimeContext)
+		if assert.NoError(t, err) {
+			i3, err := stack.Pop()
+			fmt.Println()
+			fmt.Printf("%s\n%s\n-> %s", i1.display(), i2.display(), i3.display())
+			if assert.NoError(t, err) {
+				assert.Equal(t, TYPE_LIST, i3.getType())
+				i3List := i3.asListVar()
+				assert.Equal(t, 2, i3List.Size())
+				assert.Equal(t, TYPE_LIST, i3List.items[0].getType())
+				assert.Equal(t, TYPE_LIST, i3List.items[1].getType())
+
+				i3List0 := i3List.items[0].asListVar()
+				i3List1 := i3List.items[1].asListVar()
+				assert.Equal(t, 2, i3List0.Size(), i3List0.display())
+				assert.Equal(t, 2, i3List1.Size(), i3List1.display())
+
+				i3List00 := i3List0.items[0].asNumericVar()
+				i3List01 := i3List0.items[1].asNumericVar()
+				i3List10 := i3List1.items[0].asNumericVar()
+				i3List11 := i3List1.items[1].asNumericVar()
+
+				assert.True(t, decimal.NewFromInt(3).Equal(i3List00.value), i3List00.display())
+				assert.True(t, decimal.NewFromInt(5).Equal(i3List01.value), i3List01.display())
+				assert.True(t, decimal.NewFromInt(13).Equal(i3List10.value), i3List10.display())
+				assert.True(t, decimal.NewFromInt(15).Equal(i3List11.value), i3List11.display())
+			}
+		}
+	})
+	t.Run("ExpandedCall 2-2", func(t *testing.T) {
+
+		funcBuilder := new(instrumentedExpandableFunctionFactory)
+
+		expandableTestOp := NewExpandableOperationDesc("testExpandableOp", 2, CheckNoop, 2, funcBuilder.GetApplyFunc22())
+
+		var i1 = CreateListVariable([]Variable{CreateNumericVariableFromInt(3), CreateNumericVariableFromInt(13)})
+		var i2 = CreateListVariable([]Variable{CreateNumericVariableFromInt(5), CreateNumericVariableFromInt(15)})
+
+		stack := CreateStack()
+		stack.Push(i1)
+		stack.Push(i2)
+		runtimeContext := CreateRuntimeContext(nil, stack)
+		err := expandableTestOp.Apply(runtimeContext)
+		if assert.NoError(t, err) {
+
+			if assert.Equal(t, 2, stack.Size()) {
+
+				i3, err := stack.Pop()
+				fmt.Println()
+				fmt.Printf("%s\n%s\n-> %s\n", i1.display(), i2.display(), i3.display())
+				if assert.NoError(t, err) {
+					assert.Equal(t, TYPE_LIST, i3.getType())
+					i3List := i3.asListVar()
+					assert.Equal(t, 2, i3List.Size())
+					assert.Equal(t, TYPE_LIST, i3List.items[0].getType(), "Expected TYPE_LIST(6) and got other type")
+					assert.Equal(t, TYPE_LIST, i3List.items[1].getType(), "Expected TYPE_LIST(6) and got other type")
+
+					i3List0 := i3List.items[0].asListVar()
+					i3List1 := i3List.items[1].asListVar()
+					assert.Equal(t, 2, i3List0.Size(), i3List0.display())
+					assert.Equal(t, 2, i3List1.Size(), i3List1.display())
+
+					i3List00 := i3List0.items[0].asNumericVar()
+					i3List01 := i3List0.items[1].asNumericVar()
+					i3List10 := i3List1.items[0].asNumericVar()
+					i3List11 := i3List1.items[1].asNumericVar()
+
+					assert.True(t, decimal.NewFromInt(3).Equal(i3List00.value), i3List00.display())
+					assert.True(t, decimal.NewFromInt(5).Equal(i3List01.value), i3List01.display())
+					assert.True(t, decimal.NewFromInt(13).Equal(i3List10.value), i3List10.display())
+					assert.True(t, decimal.NewFromInt(15).Equal(i3List11.value), i3List11.display())
+				}
+			}
+		}
+	})
 }

--- a/rcalc/op_test.go
+++ b/rcalc/op_test.go
@@ -58,7 +58,7 @@ func (i *instrumentedExpandableFunctionFactory) GetApplyFunc() OperationApplyFn 
 func (i *instrumentedExpandableFunctionFactory) GetApplyFunc22() OperationApplyFn {
 	return func(system System, elts ...Variable) []Variable {
 		i.callingCount += 1
-		fmt.Printf("Applyfunc called\n")
+		fmt.Printf("Applyfunc22 called\n")
 		return []Variable{elts[0], elts[1]}
 	}
 }
@@ -104,8 +104,7 @@ func TestExpandableApply(t *testing.T) {
 		err := expandableTestOp.Apply(runtimeContext)
 		if assert.NoError(t, err) {
 			i3, err := stack.Pop()
-			fmt.Println()
-			fmt.Printf("%s\n%s\n-> %s", i1.display(), i2.display(), i3.display())
+			fmt.Printf("%s\n%s\n-> %s\n", i1.display(), i2.display(), i3.display())
 			if assert.NoError(t, err) {
 				assert.Equal(t, TYPE_LIST, i3.getType())
 				i3List := i3.asListVar()
@@ -130,6 +129,33 @@ func TestExpandableApply(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("ExpandedCall 2-1 add", func(t *testing.T) {
+
+		var i1 = CreateListVariable([]Variable{CreateNumericVariableFromInt(3), CreateNumericVariableFromInt(13)})
+		var i2 = CreateListVariable([]Variable{CreateNumericVariableFromInt(5), CreateNumericVariableFromInt(15)})
+
+		stack := CreateStack()
+		stack.Push(i1)
+		stack.Push(i2)
+		runtimeContext := CreateRuntimeContext(nil, stack)
+		err := addOp.Apply(runtimeContext)
+		if assert.NoError(t, err) {
+			i3, err := stack.Pop()
+			fmt.Printf("%s\n%s\n-> %s\n", i1.display(), i2.display(), i3.display())
+			if assert.NoError(t, err) {
+				assert.Equal(t, TYPE_LIST, i3.getType())
+				i3List := i3.asListVar()
+				assert.Equal(t, 2, i3List.Size())
+				assert.Equal(t, TYPE_NUMERIC, i3List.items[0].getType())
+				assert.Equal(t, TYPE_NUMERIC, i3List.items[1].getType())
+
+				assert.True(t, decimal.NewFromInt(8).Equal(i3List.items[0].asNumericVar().value), i3List.items[0].display())
+				assert.True(t, decimal.NewFromInt(28).Equal(i3List.items[1].asNumericVar().value), i3List.items[1].display())
+			}
+		}
+	})
+
 	t.Run("ExpandedCall 2-2", func(t *testing.T) {
 
 		funcBuilder := new(instrumentedExpandableFunctionFactory)
@@ -148,30 +174,30 @@ func TestExpandableApply(t *testing.T) {
 
 			if assert.Equal(t, 2, stack.Size()) {
 
-				i3, err := stack.Pop()
-				fmt.Println()
-				fmt.Printf("%s\n%s\n-> %s\n", i1.display(), i2.display(), i3.display())
+				r1, err := stack.Pop()
+				assert.NoError(t, err)
+
+				r2, err := stack.Pop()
+				assert.NoError(t, err)
+
+				fmt.Printf("%s\n%s\n-> %s\n%s\n", i1.display(), i2.display(), r1.display(), r2.display())
 				if assert.NoError(t, err) {
-					assert.Equal(t, TYPE_LIST, i3.getType())
-					i3List := i3.asListVar()
-					assert.Equal(t, 2, i3List.Size())
-					assert.Equal(t, TYPE_LIST, i3List.items[0].getType(), "Expected TYPE_LIST(6) and got other type")
-					assert.Equal(t, TYPE_LIST, i3List.items[1].getType(), "Expected TYPE_LIST(6) and got other type")
+					assert.Equal(t, TYPE_LIST, r1.getType())
+					r1List := r1.asListVar()
+					assert.Equal(t, 2, r1List.Size())
+					assert.Equal(t, TYPE_NUMERIC, r1List.items[0].getType(), "Expected TYPE_NUMERIC(1) and got other type")
+					assert.Equal(t, TYPE_NUMERIC, r1List.items[1].getType(), "Expected TYPE_NUMERIC(1) and got other type")
 
-					i3List0 := i3List.items[0].asListVar()
-					i3List1 := i3List.items[1].asListVar()
-					assert.Equal(t, 2, i3List0.Size(), i3List0.display())
-					assert.Equal(t, 2, i3List1.Size(), i3List1.display())
+					assert.Equal(t, TYPE_LIST, r2.getType())
+					r2List := r2.asListVar()
+					assert.Equal(t, 2, r1List.Size())
+					assert.Equal(t, TYPE_NUMERIC, r2List.items[0].getType(), "Expected TYPE_NUMERIC(1) and got other type")
+					assert.Equal(t, TYPE_NUMERIC, r2List.items[1].getType(), "Expected TYPE_NUMERIC(1) and got other type")
 
-					i3List00 := i3List0.items[0].asNumericVar()
-					i3List01 := i3List0.items[1].asNumericVar()
-					i3List10 := i3List1.items[0].asNumericVar()
-					i3List11 := i3List1.items[1].asNumericVar()
-
-					assert.True(t, decimal.NewFromInt(3).Equal(i3List00.value), i3List00.display())
-					assert.True(t, decimal.NewFromInt(5).Equal(i3List01.value), i3List01.display())
-					assert.True(t, decimal.NewFromInt(13).Equal(i3List10.value), i3List10.display())
-					assert.True(t, decimal.NewFromInt(15).Equal(i3List11.value), i3List11.display())
+					assert.True(t, decimal.NewFromInt(5).Equal(r1List.items[0].asNumericVar().value), "%s (expected %d)", r1List.items[0].display(), 5)
+					assert.True(t, decimal.NewFromInt(15).Equal(r1List.items[1].asNumericVar().value), "%s (expected %d)", r1List.items[1].display(), 15)
+					assert.True(t, decimal.NewFromInt(3).Equal(r2List.items[0].asNumericVar().value), "%s (expected %d)", r2List.items[0].display(), 3)
+					assert.True(t, decimal.NewFromInt(13).Equal(r2List.items[1].asNumericVar().value), "%s (expected %d)", r2List.items[1].display(), 13)
 				}
 			}
 		}

--- a/rcalc/ops.go
+++ b/rcalc/ops.go
@@ -137,23 +137,23 @@ var BooleanLogicPackage = ActionPackage{
 
 // Stack package
 
-var dupOp = NewStackOp("dup", 1, func(elts ...Variable) []Variable {
+var dupOp = NewStackOp("dup", 1, 2, func(elts ...Variable) []Variable {
 	return []Variable{elts[0], elts[0]}
 })
 
-var dup2Op = NewStackOp("dup2", 2, func(elts ...Variable) []Variable {
+var dup2Op = NewStackOp("dup2", 2, 4, func(elts ...Variable) []Variable {
 	return []Variable{elts[1], elts[0], elts[1], elts[0]}
 })
 
-var dropOp = NewStackOp("drop", 1, func(elts ...Variable) []Variable {
+var dropOp = NewStackOp("drop", 1, 0, func(elts ...Variable) []Variable {
 	return []Variable{}
 })
 
-var drop2Op = NewStackOp("drop2", 2, func(elts ...Variable) []Variable {
+var drop2Op = NewStackOp("drop2", 2, 0, func(elts ...Variable) []Variable {
 	return []Variable{}
 })
 
-var swapOp = NewStackOp("swap", 2, func(elts ...Variable) []Variable {
+var swapOp = NewStackOp("swap", 2, 2, func(elts ...Variable) []Variable {
 	return []Variable{elts[1], elts[0]}
 })
 

--- a/rcalc/ops.go
+++ b/rcalc/ops.go
@@ -4,23 +4,23 @@ import "github.com/shopspring/decimal"
 
 // Arithmetic package
 
-var addOp = NewA2R1NumericOp("+", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
+var addOp = NewExpandedA2R1NumericOp("+", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
 	return num1.Add(num2)
 })
 
-var subOp = NewA2R1NumericOp("-", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
+var subOp = NewExpandedA2R1NumericOp("-", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
 	return num2.Sub(num1)
 })
 
-var mulOp = NewA2R1NumericOp("*", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
+var mulOp = NewExpandedA2R1NumericOp("*", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
 	return num1.Mul(num2)
 })
 
-var divOp = NewA2R1NumericOp("/", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
+var divOp = NewExpandedA2R1NumericOp("/", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
 	return num2.Div(num1)
 })
 
-var powOp = NewA2R1NumericOp("^", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
+var powOp = NewExpandedA2R1NumericOp("^", func(num1 decimal.Decimal, num2 decimal.Decimal) decimal.Decimal {
 	return num2.Pow(num1)
 })
 

--- a/rcalc/ops_for_lists.go
+++ b/rcalc/ops_for_lists.go
@@ -14,9 +14,21 @@ var toListOp = NewRawStackOpWithCheck("tolist", 1, CheckFirstInt, func(system Sy
 	return nil
 })
 
+var expandListOp = NewRawStackOpWithCheck("expandlist", 1, CheckFirstInt, func(system System, stack *Stack) error {
+	list, err := stack.Pop()
+	if err != nil {
+		return err
+	}
+	for _, item := range list.(*ListVariable).items {
+		stack.Push(item)
+	}
+	return nil
+})
+
 var ListPackage = ActionPackage{
 	staticActions: []Action{
 		&toListOp,
+		&expandListOp,
 	},
 	dynamicActions: []Action{},
 }

--- a/rcalc/ops_for_lists.go
+++ b/rcalc/ops_for_lists.go
@@ -1,0 +1,22 @@
+package rcalc
+
+var toListOp = NewRawStackOpWithCheck("tolist", 1, CheckFirstInt, func(system System, stack *Stack) error {
+	n, err := stack.Pop()
+	if err != nil {
+		return err
+	}
+	stackElts, err := stack.PopN(int(n.asNumericVar().value.IntPart()))
+	if err != nil {
+		return err
+	}
+	listVar := CreateListVariable(stackElts)
+	stack.Push(listVar)
+	return nil
+})
+
+var ListPackage = ActionPackage{
+	staticActions: []Action{
+		&toListOp,
+	},
+	dynamicActions: []Action{},
+}

--- a/rcalc/stack.go
+++ b/rcalc/stack.go
@@ -2,8 +2,9 @@ package rcalc
 
 import (
 	"fmt"
-	"google.golang.org/protobuf/proto"
 	"os"
+
+	"google.golang.org/protobuf/proto"
 	"troisdizaines.com/rcalc/rcalc/protostack"
 )
 
@@ -26,6 +27,7 @@ type Variable interface {
 	asBooleanVar() *BooleanVariable
 	asIdentifierVar() *AlgebraicExpressionVariable
 	asProgramVar() *ProgramVariable
+	asListVar() *ListVariable
 	display() string
 	String() string
 }
@@ -52,6 +54,10 @@ func (se *CommonVariable) asIdentifierVar() *AlgebraicExpressionVariable {
 
 func (se *CommonVariable) asProgramVar() *ProgramVariable {
 	panic("This is not a Program variable")
+}
+
+func (se *CommonVariable) asListVar() *ListVariable {
+	panic("This is not a List variable")
 }
 
 func (se *CommonVariable) String() string {

--- a/rcalc/system.go
+++ b/rcalc/system.go
@@ -38,6 +38,7 @@ var EXIT_ACTION = NewOperationDesc(
 	"quit",
 	0,
 	func(elts ...Variable) (bool, error) { return true, nil },
+	0,
 	func(system System, elts ...Variable) []Variable {
 		system.exit()
 		return nil

--- a/rcalc/variables.go
+++ b/rcalc/variables.go
@@ -92,7 +92,7 @@ func (l *ListVariable) display() string {
 	for i, item := range l.items {
 		displayedItems[i] = item.display()
 	}
-	return fmt.Sprintf("{ %s }", strings.Join(displayedItems, ", "))
+	return fmt.Sprintf("{ %s }", strings.Join(displayedItems, " "))
 }
 
 func (l *ListVariable) asListVar() *ListVariable {

--- a/rcalc/variables.go
+++ b/rcalc/variables.go
@@ -2,8 +2,9 @@ package rcalc
 
 import (
 	"fmt"
-	"github.com/shopspring/decimal"
 	"strings"
+
+	"github.com/shopspring/decimal"
 	"troisdizaines.com/rcalc/rcalc/protostack"
 )
 
@@ -92,6 +93,14 @@ func (l *ListVariable) display() string {
 		displayedItems[i] = item.display()
 	}
 	return fmt.Sprintf("{ %s }", strings.Join(displayedItems, ", "))
+}
+
+func (l *ListVariable) asListVar() *ListVariable {
+	return l
+}
+
+func (l *ListVariable) Size() int {
+	return len(l.items)
 }
 
 type AlgebraicExpressionNode interface {


### PR DESCRIPTION
Now, expandable operations can work on lists : 
```
{ 1 3 5 }
{ 2 4 6 }
+
```

returns 

```
{ 3 7 11 }
```

Feature tested independently of the operation + configured for `+`, `-`, `*`, `/`, `^`

Also added and `expandlist` operation to spread the list elements on stack