### PR TITLE
Upgrade setup-antlr4 action to v4.13.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
       - name: Install Antlr4
-        uses: StoneMoe/setup-antlr4@v2
+        uses: StoneMoe/setup-antlr4@v4.13.0
         with:
           download_url: 'https://www.antlr.org/download/antlr-4.13.0-complete.jar'
       - name: Install Protoc


### PR DESCRIPTION
Goal is mainly to use nodejs 16 and remove deprecation warnings