### PR TITLE
Upgrade upload-artifact action to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       - run: make test
       - run: make compile
       - name: Upload package as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: rcalc-${{matrix.os}}
           path: |


### PR DESCRIPTION
Main goal is to remove node 12 warning